### PR TITLE
Divide script into two seperate components

### DIFF
--- a/add_overridden_contracts.sh
+++ b/add_overridden_contracts.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Exit on any error
+set -e
+
+# Copy overridden contracts into main contracts directory
+cp  -R ./overridden_contracts/src/ ./snowbridge/contracts/src
+cp  -R ./overridden_contracts/test/ ./snowbridge/contracts/test
+
+# Compile the resulting contracts
+pushd ./snowbridge/contracts
+forge build
+popd

--- a/magefile.go
+++ b/magefile.go
@@ -17,6 +17,12 @@ func BuildMain() error {
 	if err != nil {
 		return err
 	}
+
+	err = sh.Run("./add_overridden_contracts.sh")
+	if err != nil {
+		return err
+	}
+
 	err = sh.Run("./update_contract_interface.sh")
 	if err != nil {
 		return err

--- a/update_contract_interface.sh
+++ b/update_contract_interface.sh
@@ -3,15 +3,6 @@
 # Exit on any error
 set -e
 
-# Copy overridden contracts into main contracts directory
-cp  -R ./overridden_contracts/src/ ./snowbridge/contracts/src
-cp  -R ./overridden_contracts/test/ ./snowbridge/contracts/test
-
-# Compile the resulting contracts
-pushd ./snowbridge/contracts
-forge build
-popd
-
 # Create Go interface to it in main directory
 jq .abi ./snowbridge/contracts/out/BeefyClient.sol/BeefyClient.json | abigen --abi - --type BeefyClient --pkg contracts --out ./relays/contracts/beefy_client.go
 jq .abi ./snowbridge/contracts/out/IGateway.sol/IGateway.json | abigen --abi - --type Gateway --pkg contracts --out ./relays/contracts/gateway.go


### PR DESCRIPTION
# Description

This PR divides the script `./update_contract_interface.sh` into two parts:
1. `add_overridden_contracts.sh`: Adds overridden contracts into snowbridge directory and build the contracts.
2. `update_contract_interface.sh`: Updates go bindings for solidity contracts.