### PR TITLE
Store Middleware address in Gateway

### DIFF
--- a/overridden_contracts/src/Gateway.sol
+++ b/overridden_contracts/src/Gateway.sol
@@ -61,6 +61,7 @@ contract Gateway is IOGateway, IInitializable, IUpgradable, Ownable {
     using SafeNativeTransfer for address payable;
 
     address public s_middleware;
+    event MiddlewareChanged(address indexed previousMiddleware, address indexed newMiddleware);
 
     address public immutable AGENT_EXECUTOR;
 
@@ -776,6 +777,12 @@ contract Gateway is IOGateway, IInitializable, IUpgradable, Ownable {
     function setMiddleware(
         address middleware
     ) external onlyOwner {
+        address oldMiddleware = s_middleware;
+
+        require(middleware != address(0), "new middleware is the zero address");
+        require(middleware != oldMiddleware, "new middleware is the same as before");
+        
         s_middleware = middleware;
+        emit MiddlewareChanged(oldMiddleware, middleware);
     }
 }

--- a/overridden_contracts/src/Gateway.sol
+++ b/overridden_contracts/src/Gateway.sol
@@ -781,11 +781,11 @@ contract Gateway is IOGateway, IInitializable, IUpgradable, Ownable {
     ) external onlyOwner {
         address oldMiddleware = s_middleware;
 
-        if(middleware != address(0)) {
+        if(middleware == address(0)) {
             revert CantSetMiddlewareToZeroAddress();
         }
 
-        if(middleware != oldMiddleware) {
+        if(middleware == oldMiddleware) {
             revert CantSetMiddlewareToSameAddress();
         }
         

--- a/overridden_contracts/src/Gateway.sol
+++ b/overridden_contracts/src/Gateway.sol
@@ -60,9 +60,6 @@ contract Gateway is IOGateway, IInitializable, IUpgradable, Ownable {
     using Address for address;
     using SafeNativeTransfer for address payable;
 
-    address public s_middleware;
-    event MiddlewareChanged(address indexed previousMiddleware, address indexed newMiddleware);
-
     address public immutable AGENT_EXECUTOR;
 
     // Verification state
@@ -91,6 +88,9 @@ contract Gateway is IOGateway, IInitializable, IUpgradable, Ownable {
 
     uint8 internal immutable FOREIGN_TOKEN_DECIMALS;
 
+    // Address of the middleware contract.
+    address public s_middleware;
+
     error InvalidProof();
     error InvalidNonce();
     error NotEnoughGas();
@@ -105,6 +105,8 @@ contract Gateway is IOGateway, IInitializable, IUpgradable, Ownable {
     error InvalidAgentExecutionPayload();
     error InvalidConstructorParams();
     error TokenNotRegistered();
+    error CantSetMiddlewareToZeroAddress();
+    error CantSetMiddlewareToSameAddress();
 
     // Message handlers can only be dispatched by the gateway itself
     modifier onlySelf() {
@@ -779,8 +781,13 @@ contract Gateway is IOGateway, IInitializable, IUpgradable, Ownable {
     ) external onlyOwner {
         address oldMiddleware = s_middleware;
 
-        require(middleware != address(0), "new middleware is the zero address");
-        require(middleware != oldMiddleware, "new middleware is the same as before");
+        if(middleware != address(0)) {
+            revert CantSetMiddlewareToZeroAddress();
+        }
+
+        if(middleware != oldMiddleware) {
+            revert CantSetMiddlewareToSameAddress();
+        }
         
         s_middleware = middleware;
         emit MiddlewareChanged(oldMiddleware, middleware);

--- a/overridden_contracts/src/Gateway.sol
+++ b/overridden_contracts/src/Gateway.sol
@@ -3,6 +3,7 @@
 pragma solidity 0.8.25;
 
 import {MerkleProof} from "openzeppelin/utils/cryptography/MerkleProof.sol";
+import {Ownable} from "openzeppelin/access/Ownable.sol";
 import {Verification} from "./Verification.sol";
 import {Assets} from "./Assets.sol";
 import {AgentExecutor} from "./AgentExecutor.sol";
@@ -55,9 +56,11 @@ import {Operators} from "./Operators.sol";
 
 import {IOGateway} from "./interfaces/IOGateway.sol";
 
-contract Gateway is IOGateway, IInitializable, IUpgradable {
+contract Gateway is IOGateway, IInitializable, IUpgradable, Ownable {
     using Address for address;
     using SafeNativeTransfer for address payable;
+
+    address public s_middleware;
 
     address public immutable AGENT_EXECUTOR;
 
@@ -767,5 +770,12 @@ contract Gateway is IOGateway, IInitializable, IUpgradable {
         // Initialize operator storage
         OperatorStorage.Layout storage operatorStorage = OperatorStorage.layout();
         operatorStorage.operator = config.rescueOperator;
+    }
+
+    /// Changes the middleware address.
+    function setMiddleware(
+        address middleware
+    ) external onlyOwner {
+        s_middleware = middleware;
     }
 }

--- a/overridden_contracts/src/Gateway.sol
+++ b/overridden_contracts/src/Gateway.sol
@@ -603,7 +603,7 @@ contract Gateway is IOGateway, IInitializable, IUpgradable, Ownable {
         emit OutboundMessageAccepted(channelID, channel.outboundNonce, messageID, ticket.payload);
     }
 
-        // Submit an outbound message to a specific channel.
+    // Submit an outbound message to a specific channel.
     // Doesn't handle fees.
     function _submitOutboundToChannel(ChannelID channelID, bytes memory payload) internal {
         Channel storage channel = _ensureChannel(channelID);
@@ -694,7 +694,7 @@ contract Gateway is IOGateway, IInitializable, IUpgradable, Ownable {
         address rescueOperator;
     }
 
-        /// Initialize storage within the `GatewayProxy` contract using this initializer.
+    /// Initialize storage within the `GatewayProxy` contract using this initializer.
     ///
     /// This initializer cannot be called externally via the proxy as the function selector
     /// is overshadowed in the proxy.
@@ -730,6 +730,8 @@ contract Gateway is IOGateway, IInitializable, IUpgradable, Ownable {
         CoreStorage.Layout storage core = CoreStorage.layout();
 
         Config memory config = abi.decode(data, (Config));
+
+        _transferOwnership(msg.sender);
 
         core.mode = config.mode;
 

--- a/overridden_contracts/src/interfaces/IOGateway.sol
+++ b/overridden_contracts/src/interfaces/IOGateway.sol
@@ -24,6 +24,8 @@ interface IOGateway is IGateway {
     // Emitted when the middleware contract address is changed by the owner.
     event MiddlewareChanged(address indexed previousMiddleware, address indexed newMiddleware);
 
+    function s_middleware() external view returns(address);
+
     function sendOperatorsData(
         bytes32[] calldata data
     ) external;
@@ -31,6 +33,4 @@ interface IOGateway is IGateway {
     function setMiddleware(
         address middleware
     ) external;
-
-    function s_middleware() external view returns(address);
 }

--- a/overridden_contracts/src/interfaces/IOGateway.sol
+++ b/overridden_contracts/src/interfaces/IOGateway.sol
@@ -27,4 +27,10 @@ interface IOGateway is IGateway {
     function sendOperatorsData(
         bytes32[] calldata data
     ) external;
+
+    function setMiddleware(
+        address middleware
+    ) external;
+
+    function s_middleware() external view returns(address);
 }

--- a/overridden_contracts/src/interfaces/IOGateway.sol
+++ b/overridden_contracts/src/interfaces/IOGateway.sol
@@ -21,6 +21,9 @@ interface IOGateway is IGateway {
     // Emitted when operators data has been created
     event OperatorsDataCreated(uint256 indexed validatorsCount, bytes payload);
 
+    // Emitted when the middleware contract address is changed by the owner.
+    event MiddlewareChanged(address indexed previousMiddleware, address indexed newMiddleware);
+
     function sendOperatorsData(
         bytes32[] calldata data
     ) external;

--- a/overridden_contracts/test/override_test/Gateway.t.sol
+++ b/overridden_contracts/test/override_test/Gateway.t.sol
@@ -264,7 +264,7 @@ contract GatewayTest is Test {
 
     function testNonOwnerCantChangeMiddleware() public {
         vm.prank(0x1111111111111111111111111111111111111111);
-        vm.expectRevert();
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector));
         IOGateway(address(gateway)).setMiddleware(0x9876543210987654321098765432109876543210);
     }
 }

--- a/overridden_contracts/test/override_test/Gateway.t.sol
+++ b/overridden_contracts/test/override_test/Gateway.t.sol
@@ -252,4 +252,19 @@ contract GatewayTest is Test {
 
         IOGateway(address(gateway)).sendOperatorsData(accounts);
     }
+
+    function testOwnerCanChangeMiddleware() public {
+        vm.expectEmit(true, true, false, false);
+        emit IOGateway.MiddlewareChanged(address(0), 0x0123456789012345678901234567890123456789);
+
+        IOGateway(address(gateway)).setMiddleware(0x0123456789012345678901234567890123456789);
+
+        require(IOGateway(address(gateway)).s_middleware() == 0x0123456789012345678901234567890123456789);
+    }
+
+    function testNonOwnerCantChangeMiddleware() public {
+        vm.prank(0x1111111111111111111111111111111111111111);
+        vm.expectRevert();
+        IOGateway(address(gateway)).setMiddleware(0x9876543210987654321098765432109876543210);
+    }
 }

--- a/overridden_contracts/test/override_test/Gateway.t.sol
+++ b/overridden_contracts/test/override_test/Gateway.t.sol
@@ -35,7 +35,6 @@ import {AgentExecutor} from "../../src/AgentExecutor.sol";
 import {SetOperatingModeParams} from "../../src/Params.sol";
 
 import {Strings} from "openzeppelin/utils/Strings.sol";
-import {Ownable} from "openzeppelin/contracts/access/Ownable.sol";
 
 import {Gateway} from "../../src/Gateway.sol";
 import {IOGateway} from "../../src/interfaces/IOGateway.sol";
@@ -264,8 +263,9 @@ contract GatewayTest is Test {
     }
 
     function testNonOwnerCantChangeMiddleware() public {
-        vm.prank(0x1111111111111111111111111111111111111111);
-        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector));
+        address notOwner = makeAddr("notOwner");
+        vm.prank(notOwner);
+        vm.expectRevert("Ownable: caller is not the owner");
         IOGateway(address(gateway)).setMiddleware(0x9876543210987654321098765432109876543210);
     }
 }

--- a/overridden_contracts/test/override_test/Gateway.t.sol
+++ b/overridden_contracts/test/override_test/Gateway.t.sol
@@ -35,6 +35,7 @@ import {AgentExecutor} from "../../src/AgentExecutor.sol";
 import {SetOperatingModeParams} from "../../src/Params.sol";
 
 import {Strings} from "openzeppelin/utils/Strings.sol";
+import {Ownable} from "openzeppelin/contracts/access/Ownable.sol";
 
 import {Gateway} from "../../src/Gateway.sol";
 import {IOGateway} from "../../src/interfaces/IOGateway.sol";


### PR DESCRIPTION
Adds an owner to the Gateway, which can set Middleware address to be used in the future.