### PR TITLE
Move owner and middleware to deterministic storage

### DIFF
--- a/overridden_contracts/src/Gateway.sol
+++ b/overridden_contracts/src/Gateway.sol
@@ -55,8 +55,9 @@ import {UD60x18, ud60x18, convert} from "prb/math/src/UD60x18.sol";
 import {Operators} from "./Operators.sol";
 
 import {IOGateway} from "./interfaces/IOGateway.sol";
+import {GatewayCoreStorage} from "./storage/GatewayCoreStorage.sol";
 
-contract Gateway is IOGateway, IInitializable, IUpgradable, Ownable {
+contract Gateway is IOGateway, IInitializable, IUpgradable {
     using Address for address;
     using SafeNativeTransfer for address payable;
 
@@ -88,9 +89,6 @@ contract Gateway is IOGateway, IInitializable, IUpgradable, Ownable {
 
     uint8 internal immutable FOREIGN_TOKEN_DECIMALS;
 
-    // Address of the middleware contract.
-    address public s_middleware;
-
     error InvalidProof();
     error InvalidNonce();
     error NotEnoughGas();
@@ -111,6 +109,15 @@ contract Gateway is IOGateway, IInitializable, IUpgradable, Ownable {
     // Message handlers can only be dispatched by the gateway itself
     modifier onlySelf() {
         if (msg.sender != address(this)) {
+            revert Unauthorized();
+        }
+        _;
+    }
+
+    // Can only be called by the owner of the contract.
+    modifier onlyOwner() {
+        GatewayCoreStorage.Layout storage layout = GatewayCoreStorage.layout();
+        if (msg.sender != layout.owner) {
             revert Unauthorized();
         }
         _;
@@ -777,11 +784,29 @@ contract Gateway is IOGateway, IInitializable, IUpgradable, Ownable {
         operatorStorage.operator = config.rescueOperator;
     }
 
+    function _transferOwnership(
+        address newOwner
+    ) internal {
+        GatewayCoreStorage.Layout storage layout = GatewayCoreStorage.layout();
+
+        address oldOwner = layout.owner;
+        layout.owner = newOwner;
+
+        emit OwnershipTransferred(oldOwner, newOwner);
+    }
+
+    function transferOwnership(
+        address newOwner
+    ) external onlyOwner {
+        _transferOwnership(newOwner);
+    }
+
     /// Changes the middleware address.
     function setMiddleware(
         address middleware
     ) external onlyOwner {
-        address oldMiddleware = s_middleware;
+        GatewayCoreStorage.Layout storage layout = GatewayCoreStorage.layout();
+        address oldMiddleware = layout.middleware;
 
         if(middleware == address(0)) {
             revert CantSetMiddlewareToZeroAddress();
@@ -791,7 +816,12 @@ contract Gateway is IOGateway, IInitializable, IUpgradable, Ownable {
             revert CantSetMiddlewareToSameAddress();
         }
         
-        s_middleware = middleware;
+        layout.middleware = middleware;
         emit MiddlewareChanged(oldMiddleware, middleware);
+    }
+
+    function s_middleware() external view returns(address) {
+        GatewayCoreStorage.Layout storage layout = GatewayCoreStorage.layout();
+        return layout.middleware;
     }
 }

--- a/overridden_contracts/src/interfaces/IOGateway.sol
+++ b/overridden_contracts/src/interfaces/IOGateway.sol
@@ -21,6 +21,9 @@ interface IOGateway is IGateway {
     // Emitted when operators data has been created
     event OperatorsDataCreated(uint256 indexed validatorsCount, bytes payload);
 
+    // Emitted when owner of the gateway is changed.
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
     // Emitted when the middleware contract address is changed by the owner.
     event MiddlewareChanged(address indexed previousMiddleware, address indexed newMiddleware);
 

--- a/overridden_contracts/src/storage/GatewayCoreStorage.sol
+++ b/overridden_contracts/src/storage/GatewayCoreStorage.sol
@@ -1,0 +1,33 @@
+//SPDX-License-Identifier: GPL-3.0-or-later
+
+// Copyright (C) Moondance Labs Ltd.
+// This file is part of Tanssi.
+// Tanssi is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// Tanssi is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with Tanssi.  If not, see <http://www.gnu.org/licenses/>
+pragma solidity 0.8.25;
+
+library GatewayCoreStorage {
+    struct Layout {
+        // Owner of the gateway for configuration purposes.
+        address owner;
+        // Address of the Symbiotic middleware to properly execute messages.
+        address middleware;
+    }
+
+    bytes32 internal constant SLOT = keccak256("tanssi-bridge-relayer.gateway.core");
+
+    function layout() internal pure returns (Layout storage ptr) {
+        bytes32 slot = SLOT;
+        assembly {
+            ptr.slot := slot
+        }
+    }
+}

--- a/overridden_contracts/test/override_test/Gateway.t.sol
+++ b/overridden_contracts/test/override_test/Gateway.t.sol
@@ -265,7 +265,7 @@ contract GatewayTest is Test {
     function testNonOwnerCantChangeMiddleware() public {
         address notOwner = makeAddr("notOwner");
         vm.prank(notOwner);
-        vm.expectRevert("Ownable: caller is not the owner");
+        vm.expectRevert(abi.encodeWithSelector(Gateway.Unauthorized.selector));
         IOGateway(address(gateway)).setMiddleware(0x9876543210987654321098765432109876543210);
     }
 }


### PR DESCRIPTION
Use a deterministic storage slot strategy for our custom storages (currently owner and middleware) to make upgradability easier.