### PR TITLE
Fixed edge case where distributeRewards could revert but the submit was considered successful

### DIFF
--- a/overridden_contracts/src/Gateway.sol
+++ b/overridden_contracts/src/Gateway.sol
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2023 Snowfork <hello@snowfork.com>
 pragma solidity 0.8.25;
 
+import {console2} from "forge-std/console2.sol";
 import {MerkleProof} from "openzeppelin/utils/cryptography/MerkleProof.sol";
 import {Ownable} from "openzeppelin/access/Ownable.sol";
 import {Verification} from "./Verification.sol";
@@ -107,6 +108,24 @@ contract Gateway is IOGateway, IInitializable, IUpgradable {
     error CantSetMiddlewareToZeroAddress();
     error CantSetMiddlewareToSameAddress();
     error MiddlewareNotSet();
+    error EUnableToProcessRewardsB(
+        uint256 epoch,
+        uint256 eraIndex,
+        address tokenAddress,
+        uint256 totalPointsToken,
+        uint256 totalTokensInflated,
+        bytes32 rewardsRoot,
+        bytes errorBytes
+    );
+    error EUnableToProcessRewardsS(
+        uint256 epoch,
+        uint256 eraIndex,
+        address tokenAddress,
+        uint256 totalPointsToken,
+        uint256 totalTokensInflated,
+        bytes32 rewardsRoot,
+        string errorString
+    );
 
     // Message handlers can only be dispatched by the gateway itself
     modifier onlySelf() {
@@ -509,7 +528,6 @@ contract Gateway is IOGateway, IInitializable, IUpgradable {
             revert MiddlewareNotSet();
         }
 
-        // Probably need to send me the token to be minted?
         (
             uint256 epoch,
             uint256 eraIndex,
@@ -525,11 +543,11 @@ contract Gateway is IOGateway, IInitializable, IUpgradable {
         try IMiddlewareBasic(middlewareAddress).distributeRewards(
             epoch, eraIndex, totalPointsToken, totalTokensInflated, rewardsRoot, tokenAddress
         ) {} catch Error(string memory err) {
-            emit UnableToProcessRewardsS(
+            revert EUnableToProcessRewardsS(
                 epoch, eraIndex, tokenAddress, totalPointsToken, totalTokensInflated, rewardsRoot, err
             );
         } catch (bytes memory err) {
-            emit UnableToProcessRewardsB(
+            revert EUnableToProcessRewardsB(
                 epoch, eraIndex, tokenAddress, totalPointsToken, totalTokensInflated, rewardsRoot, err
             );
         }

--- a/overridden_contracts/src/interfaces/IOGateway.sol
+++ b/overridden_contracts/src/interfaces/IOGateway.sol
@@ -51,7 +51,7 @@ interface IOGateway is IGateway {
         uint256 totalPointsToken,
         uint256 totalTokensInflated,
         bytes32 rewardsRoot,
-        bytes error
+        bytes errorBytes
     );
 
     // Emitted when the middleware fails to process rewards
@@ -62,7 +62,7 @@ interface IOGateway is IGateway {
         uint256 totalPointsToken,
         uint256 totalTokensInflated,
         bytes32 rewardsRoot,
-        string error
+        string errorString
     );
 
     // Emitted when the middleware fails to apply the slash message

--- a/overridden_contracts/test/override_test/Gateway.t.sol
+++ b/overridden_contracts/test/override_test/Gateway.t.sol
@@ -542,9 +542,6 @@ contract GatewayTest is Test {
         IOGateway(address(gateway)).setMiddleware(0x0123456789012345678901234567890123456789);
 
         bytes memory empty;
-        // Expect the gateway to emit `InboundMessageDispatched`
-        // For some reason when you are loading an address not complying an interface, you get an empty message
-        // It still serves us to know that this is the reason
         vm.expectEmit(true, true, true, true);
         emit IOGateway.UnableToProcessRewardsMessageB(empty);
         vm.expectEmit(true, true, true, true);
@@ -583,9 +580,8 @@ contract GatewayTest is Test {
         bytes32 expectedForeignTokenId = bytes32(uint256(1));
 
         address expectedTokenAddress = MockGateway(address(gateway)).tokenAddressOf(expectedForeignTokenId);
-
-        vm.expectEmit(true, true, true, true);
-        emit IOGateway.UnableToProcessRewardsB(
+        bytes memory expectedBytes = abi.encodeWithSelector(
+            Gateway.EUnableToProcessRewardsB.selector,
             expectedEpoch,
             expectedEraIndex,
             expectedTokenAddress,
@@ -594,8 +590,11 @@ contract GatewayTest is Test {
             expectedRewardsRoot,
             expectedError
         );
+
         vm.expectEmit(true, true, true, true);
-        emit IGateway.InboundMessageDispatched(assetHubParaID.into(), 1, messageID, true);
+        emit IOGateway.UnableToProcessRewardsMessageB(expectedBytes);
+        vm.expectEmit(true, true, true, true);
+        emit IGateway.InboundMessageDispatched(assetHubParaID.into(), 1, messageID, false);
 
         hoax(relayer, 1 ether);
         IGateway(address(gateway)).submitV1(


### PR DESCRIPTION
Hotfix for `distributeRewards` revert => `submitV1` would be successful which was incorrect