### PR TITLE
Rewards: Use timestamp instead of epoch

### DIFF
--- a/overridden_contracts/src/Gateway.sol
+++ b/overridden_contracts/src/Gateway.sol
@@ -528,6 +528,7 @@ contract Gateway is IOGateway, IInitializable, IUpgradable {
             revert MiddlewareNotSet();
         }
 
+        //TODO revert back to epoch when we have it
         (
             uint256 timestamp,
             uint256 eraIndex,
@@ -540,6 +541,7 @@ contract Gateway is IOGateway, IInitializable, IUpgradable {
         Assets.mintForeignToken(foreignTokenId, middlewareAddress, totalTokensInflated);
 
         address tokenAddress = Assets.tokenAddressOf(foreignTokenId);
+
         uint48 epoch = IMiddlewareBasic(middlewareAddress).getEpochAtTs(uint48(timestamp));
         try IMiddlewareBasic(middlewareAddress).distributeRewards(
             epoch, eraIndex, totalPointsToken, totalTokensInflated, rewardsRoot, tokenAddress

--- a/overridden_contracts/src/Gateway.sol
+++ b/overridden_contracts/src/Gateway.sol
@@ -529,7 +529,7 @@ contract Gateway is IOGateway, IInitializable, IUpgradable {
         }
 
         (
-            uint256 epoch,
+            uint256 timestamp,
             uint256 eraIndex,
             uint256 totalPointsToken,
             uint256 totalTokensInflated,
@@ -540,15 +540,16 @@ contract Gateway is IOGateway, IInitializable, IUpgradable {
         Assets.mintForeignToken(foreignTokenId, middlewareAddress, totalTokensInflated);
 
         address tokenAddress = Assets.tokenAddressOf(foreignTokenId);
+        uint48 epoch = IMiddlewareBasic(middlewareAddress).getEpochAtTs(uint48(timestamp));
         try IMiddlewareBasic(middlewareAddress).distributeRewards(
             epoch, eraIndex, totalPointsToken, totalTokensInflated, rewardsRoot, tokenAddress
         ) {} catch Error(string memory err) {
             revert EUnableToProcessRewardsS(
-                epoch, eraIndex, tokenAddress, totalPointsToken, totalTokensInflated, rewardsRoot, err
+                timestamp, eraIndex, tokenAddress, totalPointsToken, totalTokensInflated, rewardsRoot, err
             );
         } catch (bytes memory err) {
             revert EUnableToProcessRewardsB(
-                epoch, eraIndex, tokenAddress, totalPointsToken, totalTokensInflated, rewardsRoot, err
+                timestamp, eraIndex, tokenAddress, totalPointsToken, totalTokensInflated, rewardsRoot, err
             );
         }
     }


### PR DESCRIPTION
Change to use timestamp instead of epoch for sending rewards