### PR TITLE
[#21] SRLabs - Optimistic result even if nothing has been executed

### DIFF
--- a/overridden_contracts/src/Gateway.sol
+++ b/overridden_contracts/src/Gateway.sol
@@ -294,7 +294,7 @@ contract Gateway is IOGateway, IInitializable, IUpgradable {
                 emit UnableToProcessRewardsMessageB(err);
                 success = false;
             }
-        } else{
+        } else {
             success = false;
             emit NotImplementedCommand();
         }

--- a/overridden_contracts/src/Gateway.sol
+++ b/overridden_contracts/src/Gateway.sol
@@ -296,7 +296,7 @@ contract Gateway is IOGateway, IInitializable, IUpgradable {
             }
         } else {
             success = false;
-            emit NotImplementedCommand();
+            emit NotImplementedCommand(message.command);
         }
 
         // Calculate a gas refund, capped to protect against huge spikes in `tx.gasprice`

--- a/overridden_contracts/src/Gateway.sol
+++ b/overridden_contracts/src/Gateway.sol
@@ -294,6 +294,9 @@ contract Gateway is IOGateway, IInitializable, IUpgradable {
                 emit UnableToProcessRewardsMessageB(err);
                 success = false;
             }
+        } else{
+            success = false;
+            emit NotImplementedCommand();
         }
 
         // Calculate a gas refund, capped to protect against huge spikes in `tx.gasprice`

--- a/overridden_contracts/src/interfaces/IOGateway.sol
+++ b/overridden_contracts/src/interfaces/IOGateway.sol
@@ -14,7 +14,7 @@
 // along with Tanssi.  If not, see <http://www.gnu.org/licenses/>
 pragma solidity ^0.8.0;
 
-import {ParaID} from "../Types.sol";
+import {ParaID, Command} from "../Types.sol";
 import {IGateway} from "./IGateway.sol";
 
 interface IOGateway is IGateway {

--- a/overridden_contracts/src/interfaces/IOGateway.sol
+++ b/overridden_contracts/src/interfaces/IOGateway.sol
@@ -50,7 +50,7 @@ interface IOGateway is IGateway {
     event UnableToProcessRewardsMessageS(string error);
 
     // Emitted when a non accepted command is received
-    event NotImplementedCommand();
+    event NotImplementedCommand(Command command);
 
     // Slash struct, used to decode slashes, which are identified by
     // operatorKey to be slashed

--- a/overridden_contracts/src/interfaces/IOGateway.sol
+++ b/overridden_contracts/src/interfaces/IOGateway.sol
@@ -49,6 +49,9 @@ interface IOGateway is IGateway {
     // Emitted when the middleware fails to apply the slash message
     event UnableToProcessRewardsMessageS(string error);
 
+    // Emitted when a non accepted command is received
+    event NotImplementedCommand();
+
     // Slash struct, used to decode slashes, which are identified by
     // operatorKey to be slashed
     // slashFraction to be applied as parts per billion

--- a/overridden_contracts/test/override_test/Gateway.t.sol
+++ b/overridden_contracts/test/override_test/Gateway.t.sol
@@ -632,4 +632,24 @@ contract GatewayTest is Test {
             assertNotEq(entries[i].topics[0], IOGateway.UnableToProcessRewardsMessageS.selector);
         }
     }
+
+    // middleware set, complying interface and rewards processed
+    function testCommandUnrecognizedShouldEmitNotImplementedCommand() public {
+        deal(assetHubAgent, 50 ether);
+        Command command = Command.Reserved12;
+
+        vm.expectEmit(true,false,false,false);
+        emit IOGateway.NotImplementedCommand();
+
+        vm.expectEmit(true, true, true, true);
+        emit IGateway.InboundMessageDispatched(assetHubParaID.into(), 1, messageID, false);
+
+        hoax(relayer, 1 ether);
+        vm.recordLogs();
+        IGateway(address(gateway)).submitV1(
+            InboundMessage(assetHubParaID.into(), 1, command, hex"", maxDispatchGas, maxRefund, reward, messageID),
+            proof,
+            makeMockProof()
+        );
+    }
 }

--- a/overridden_contracts/test/override_test/Gateway.t.sol
+++ b/overridden_contracts/test/override_test/Gateway.t.sol
@@ -638,7 +638,7 @@ contract GatewayTest is Test {
         deal(assetHubAgent, 50 ether);
         Command command = Command.Reserved12;
 
-        vm.expectEmit(true,false,false,false);
+        vm.expectEmit(true, false, false, false);
         emit IOGateway.NotImplementedCommand();
 
         vm.expectEmit(true, true, true, true);

--- a/overridden_contracts/test/override_test/Gateway.t.sol
+++ b/overridden_contracts/test/override_test/Gateway.t.sol
@@ -639,7 +639,7 @@ contract GatewayTest is Test {
         Command command = Command.Reserved12;
 
         vm.expectEmit(true, false, false, false);
-        emit IOGateway.NotImplementedCommand();
+        emit IOGateway.NotImplementedCommand(Command.Reserved12);
 
         vm.expectEmit(true, true, true, true);
         emit IGateway.InboundMessageDispatched(assetHubParaID.into(), 1, messageID, false);


### PR DESCRIPTION
This PR aims to fix optimistic returns by setting `success = false` and emitting `NotImplementedCommand()` event for easier traceability. This won't ever make the gateway to revert disrupting execution of the normal flow for message passing between substrate-eth.

https://github.com/moondance-labs/tanssi-sr-labs/issues/21