### PR TITLE
[fix] Use correct action to setup go and prevent resetting repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,9 +32,9 @@ jobs:
           node-version: "14"
 
       - name: Setup go
-        uses: actions/checkout@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: "^1.21.0"
+          go-version: '^1.21.0'
 
       - name: Install Go tools
         run: >


### PR DESCRIPTION
# Description
This PR uses `actions/setup-go@v5` instead of `actions/checkout@v4` which was not installing the correct version of go, but also was causing repository to reset to main head.